### PR TITLE
Adding IPv6 (NDP) support

### DIFF
--- a/src/arp/cache.rs
+++ b/src/arp/cache.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use pnet::datalink::{MacAddr, NetworkInterface};
 use pnet::packet::arp::ArpOperations;
 
-use super::arp::ArpMonitor;
+use super::ArpMonitor;
 
 pub struct ArpCache {
     entries: Arc<Mutex<HashMap<Ipv4Addr, MacAddr>>>,

--- a/src/arp/mod.rs
+++ b/src/arp/mod.rs
@@ -11,6 +11,9 @@ use pnet::packet::{
 
 use super::find_ipv4_addr;
 
+pub mod cache;
+pub use cache::ArpCache;
+
 /// ArpMonitor is used to listen for ARP Requests/Replies on a given interface
 pub struct ArpMonitor {
     interface: NetworkInterface,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use pnet::datalink::{MacAddr, NetworkInterface};
 
-/// ARP functions like monitoring & making requests
+/// ARP functions like monitoring & making requests, and an ArpCache
 pub mod arp;
 
-/// ARP Cache
-pub mod arp_cache;
+/// NDP functions like monitoring & making requests, and an NdpCache
+pub mod ndp;
 
 /// Routing/Forwarding Table Lookup
 pub mod routes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use pnet::datalink::{self, NetworkInterface};
 use pnet::packet::arp::ArpOperations;
-use pnet::packet::icmpv6::{ndp as pnet_ndp, Icmpv6Packet, Icmpv6Types};
 use structopt::StructOpt;
 
 use network_tools::{arp, ndp, routes};
@@ -35,8 +34,8 @@ pub enum Command {
         /// Monitor until up to this many NDP packets seen
         count: usize,
     },
-    // /// Send an NDP request for a given IPv6 Address
-    // RequestNdp { address: std::net::Ipv6Addr },
+    /// Send an NDP request for a given IPv6 Address
+    RequestNdp { address: std::net::Ipv6Addr },
 }
 
 fn main() {
@@ -177,6 +176,12 @@ fn main() {
                     limit -= 1;
                 }
             }
+        }
+        Command::RequestNdp { address } => {
+            let interface = get_interface(interfaces, args.interface.as_ref());
+            let requester = ndp::NdpRequest::new(&interface, address);
+            let hw_addr = requester.request().unwrap();
+            eprintln!("{} has MAC Address {}", address, hw_addr);
         }
     }
 }

--- a/src/ndp/cache.rs
+++ b/src/ndp/cache.rs
@@ -1,0 +1,122 @@
+use std::collections::HashMap;
+use std::net::Ipv6Addr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use pnet::datalink::{MacAddr, NetworkInterface};
+
+use super::{NdpMonitor, NdpPacket};
+
+pub struct NdpCache {
+    entries: Arc<Mutex<HashMap<Ipv6Addr, MacAddr>>>,
+    /// Pending IP Addresses (value: request has been sent)
+    pending_requests: Arc<Mutex<HashMap<Ipv6Addr, bool>>>,
+    /// Own the background thread so it is not dropped
+    _background: std::thread::JoinHandle<Result<(), std::io::Error>>,
+}
+
+impl NdpCache {
+    pub fn new(interface: &NetworkInterface) -> Self {
+        let entries = Arc::new(Mutex::new(HashMap::new()));
+        let requests = Arc::new(Mutex::new(HashMap::new()));
+
+        let monitor = {
+            let entries = entries.clone();
+            let requests = requests.clone();
+            let iface = interface.clone();
+            std::thread::spawn(move || run_ndp_monitor(iface, entries, requests))
+        };
+
+        Self {
+            entries: entries.clone(),
+            pending_requests: requests.clone(),
+            _background: monitor,
+        }
+    }
+
+    /// Get a copy of the current Ndp cache entries
+    pub fn get_entries(&self) -> HashMap<Ipv6Addr, MacAddr> {
+        self.entries.lock().unwrap().clone()
+    }
+
+    /// Check `NdpCache` for a `MacAddr` entry for a given `Ipv6Addr`
+    /// If the entry does not exist, `None` is immediately returned and
+    /// an NDP request is queued for a later `get()` attempt
+    pub fn try_get(&self, addr: Ipv6Addr) -> Option<MacAddr> {
+        if let Some(mac) = self.entries.lock().unwrap().get(&addr) {
+            Some(*mac)
+        } else {
+            // If this IP isn't already in requests, add it
+            self.pending_requests
+                .lock()
+                .unwrap()
+                .entry(addr)
+                .or_insert(false);
+            None
+        }
+    }
+
+    /// Check `NdpCache` for a `MacAddr` entry for a given `Ipv6Addr`
+    /// If the entry does not exist, an NDP request is sent and this call blocks
+    /// until either an NDP reply is received or the `timeout` duration passes.
+    pub fn get(&self, addr: Ipv6Addr, timeout: Duration) -> Option<MacAddr> {
+        let maybe_mac = {
+            let entries = self.entries.lock().unwrap();
+            entries.get(&addr).map(|m| *m)
+        };
+        if let Some(mac) = maybe_mac {
+            Some(mac)
+        } else {
+            {
+                let mut pending = self.pending_requests.lock().unwrap();
+                // If this IP isn't already in requests, add it
+                pending.entry(addr).or_insert(false);
+            }
+            let start = std::time::Instant::now();
+            loop {
+                std::thread::sleep(Duration::from_millis(10));
+                if let Some(mac) = self.try_get(addr) {
+                    return Some(mac);
+                }
+                if start.elapsed() > timeout {
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+fn run_ndp_monitor(
+    interface: NetworkInterface,
+    entries: Arc<Mutex<HashMap<Ipv6Addr, MacAddr>>>,
+    pending_requests: Arc<Mutex<HashMap<Ipv6Addr, bool>>>,
+) -> std::io::Result<()> {
+    let mut monitor = NdpMonitor::new(&interface)?;
+
+    loop {
+        for (pending, request_sent) in pending_requests.lock().unwrap().iter_mut() {
+            if *request_sent {
+                continue;
+            }
+            if let Ok(_) = monitor.send_solicitation(*pending) {
+                *request_sent = true;
+            }
+        }
+        if let Some(packet) = monitor.next() {
+            match packet {
+                NdpPacket::NeighborAdvertisement {
+                    src: _,
+                    src_mac,
+                    target,
+                } => {
+                    // Check to see if this is the reply to a pending request
+                    let mut requests = pending_requests.lock().unwrap();
+                    if let Some((ip, _)) = requests.remove_entry(&target) {
+                        entries.lock().unwrap().insert(ip, src_mac);
+                    }
+                }
+                _ => (),
+            }
+        }
+    }
+}

--- a/src/ndp/mod.rs
+++ b/src/ndp/mod.rs
@@ -1,0 +1,224 @@
+use std::cell::RefCell;
+use std::io;
+use std::net::Ipv6Addr;
+
+use pnet::datalink::{self, Channel, MacAddr, NetworkInterface};
+use pnet::packet::icmpv6::{ndp as pnet_ndp, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
+use pnet::packet::ip::IpNextHeaderProtocols;
+use pnet::packet::ipv6::Ipv6Packet;
+use pnet::packet::{
+    ethernet::{EtherType, EtherTypes, EthernetPacket, MutableEthernetPacket},
+    MutablePacket, Packet,
+};
+
+pub enum NdpPacket {
+    NeighborSolicitation {
+        target: Ipv6Addr,
+    },
+    NeighborAdvertisement {
+        target: Ipv6Addr, /*, mac: MacAddr */
+    },
+}
+
+/// NdpMonitor is used to listen for IPv6 NDP Requests/Replies on a given interface
+pub struct NdpMonitor {
+    interface: NetworkInterface,
+    /// Channel Receiver for packets
+    tx: RefCell<Box<dyn datalink::DataLinkSender>>,
+    /// Channel Receiver for packets
+    rx: RefCell<Box<dyn datalink::DataLinkReceiver>>,
+}
+
+impl NdpMonitor {
+    /// Create a new NdpMonitor for a given interface
+    pub fn new(interface: &NetworkInterface) -> io::Result<Self> {
+        let (tx, rx) = match datalink::channel(&interface, Default::default())? {
+            Channel::Ethernet(tx, rx) => (tx, rx),
+            _ => {
+                // Only Channel::Ethernet is supported currently
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Invalid interface channel type",
+                ));
+            }
+        };
+        Ok(Self {
+            interface: interface.clone(),
+            tx: RefCell::new(tx),
+            rx: RefCell::new(rx),
+        })
+    }
+
+    // pub fn send_request(&self, addr: Ipv4Addr) -> io::Result<()> {
+    //     let mut tx = self.tx.borrow_mut();
+    //     let request = build_request(&self.interface, addr)?;
+    //     match tx.send_to(request.packet(), None) {
+    //         Some(Ok(_)) => Ok(()),
+    //         Some(Err(err)) => return Err(err),
+    //         None => Err(io::Error::new(
+    //             io::ErrorKind::BrokenPipe,
+    //             "Channel is no longer available",
+    //         )),
+    //     }
+    // }
+}
+
+impl<'a> Iterator for NdpMonitor {
+    type Item = NdpPacket;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.rx.borrow_mut().next() {
+            Ok(data) => {
+                if let Some(packet) = EthernetPacket::new(data) {
+                    match packet.get_ethertype() {
+                        // We only want to operate on IPv6 packets
+                        EtherType(0x86dd) => extract_ndp_packet(&packet),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+fn extract_ndp_packet<'a>(ethernet: &EthernetPacket<'a>) -> Option<NdpPacket> {
+    Ipv6Packet::new(ethernet.payload()).and_then(|ipv6| match ipv6.get_next_header() {
+        IpNextHeaderProtocols::Icmpv6 => {
+            Icmpv6Packet::new(ipv6.payload()).and_then(|icmpv6| match icmpv6.get_icmpv6_type() {
+                Icmpv6Types::NeighborSolicit => {
+                    pnet_ndp::NeighborSolicitPacket::new(icmpv6.payload()).and_then(|ns| {
+                        Some(NdpPacket::NeighborSolicitation {
+                            // src: ipv6.get_source(),
+                            target: ns.get_target_addr(),
+                        })
+                    })
+                }
+                Icmpv6Types::NeighborAdvert => {
+                    pnet_ndp::NeighborAdvertPacket::new(icmpv6.payload()).and_then(|na| {
+                        for opt in na.get_options() {
+                            if opt.option_type == pnet_ndp::NdpOptionTypes::TargetLLAddr {
+                                dbg!(&opt);
+                                return Some(NdpPacket::NeighborAdvertisement {
+                                    // src: ipv6.get_source(),
+                                    target: na.get_target_addr(),
+                                    // mac: na.get_,
+                                });
+                            }
+                        }
+                        None
+                    })
+                }
+                _ => None,
+            })
+        }
+        _ => None,
+    })
+}
+/*
+/// NdpRequest is used to send an Ndp Requests and wait for the reply
+pub struct NdpRequest<'a> {
+    /// Interface to monitor
+    interface: &'a NetworkInterface,
+    /// IP Address that the request is targeting
+    address: Ipv4Addr,
+}
+
+impl<'a> NdpRequest<'a> {
+    /// Create a new NdpRequest for a given interface
+    pub fn new(interface: &'a NetworkInterface, address: Ipv4Addr) -> Self {
+        Self { interface, address }
+    }
+
+    /// Start the Ndp Request/Reply process
+    pub fn request(&self) -> io::Result<datalink::MacAddr> {
+        let (mut tx, mut rx) = match datalink::channel(&self.interface, Default::default())? {
+            Channel::Ethernet(tx, rx) => (tx, rx),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Invalid interface channel type",
+                ))
+            }
+        };
+
+        // Build and Send an Ndp Request
+        let request = build_request(&self.interface, self.address)?;
+        // Send the packet bytes via the `tx` Channel for our interface
+        match tx.send_to(request.packet(), None) {
+            Some(Ok(_)) => {
+                println!("Sent Ndp Request to {}", self.address);
+            }
+            Some(Err(err)) => return Err(err),
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "Channel is no longer available",
+                ))
+            }
+        }
+
+        // Now monitor Ndp packets and listen for Reply
+        while let Ok(data) = rx.next() {
+            if let Some(packet) = EthernetPacket::new(data) {
+                match packet.get_ethertype() {
+                    EtherType(0x0806) => {
+                        if let Some(ndp) = NdpPacket::new(&packet.payload()) {
+                            match ndp.get_operation() {
+                                NdpOperations::Reply => {
+                                    // Check to see if this is the reply to our request
+                                    if ndp.get_sender_proto_addr() == self.address {
+                                        return Ok(ndp.get_sender_hw_addr());
+                                    }
+                                }
+                                _ => (),
+                            }
+                        }
+                    }
+                    _ => (),
+                }
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "Stopped receiving packets",
+        ))
+    }
+}
+
+pub fn build_request(
+    interface: &NetworkInterface,
+    addr: Ipv4Addr,
+) -> io::Result<MutableEthernetPacket> {
+    let mut ethernet_packet = MutableEthernetPacket::owned(vec![0u8; 42]).unwrap();
+
+    let hw_addr = interface
+        .mac
+        .ok_or_else(|| io::Error::new(io::ErrorKind::AddrNotAvailable, "No MAC Address present"))?;
+    let source_ip = find_ipv4_addr(&interface).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::AddrNotAvailable, "No IPv4 Address present")
+    })?;
+
+    ethernet_packet.set_destination(MacAddr::broadcast());
+    ethernet_packet.set_source(hw_addr);
+    ethernet_packet.set_ethertype(EtherTypes::Arp);
+
+    let mut ndp_packet = MutableArpPacket::owned(vec![0; 28]).unwrap();
+
+    ndp_packet.set_hardware_type(ArpHardwareTypes::Ethernet);
+    ndp_packet.set_protocol_type(EtherTypes::Ipv4);
+    ndp_packet.set_hw_addr_len(6);
+    ndp_packet.set_proto_addr_len(4);
+    ndp_packet.set_operation(ArpOperations::Request);
+    ndp_packet.set_sender_hw_addr(hw_addr);
+    ndp_packet.set_sender_proto_addr(source_ip);
+    ndp_packet.set_target_hw_addr(MacAddr::zero());
+    ndp_packet.set_target_proto_addr(addr);
+
+    ethernet_packet.set_payload(ndp_packet.packet_mut());
+
+    Ok(ethernet_packet)
+}
+*/

--- a/src/ndp/mod.rs
+++ b/src/ndp/mod.rs
@@ -14,6 +14,9 @@ use pnet::packet::{
 
 use super::find_ipv6_addr;
 
+mod cache;
+pub use cache::NdpCache;
+
 const NDP_MAC_PREFIX: [u8; 3] = [0x33, 0x33, 0xff];
 const NDP_IP_ADDR: &str = "ff02::1:0:0";
 
@@ -24,20 +27,19 @@ pub enum NdpPacket {
         src_mac: MacAddr,
         target: Ipv6Addr,
     },
-    /// Link Layer Node Response ()
+    /// Link Layer Node Response
     NeighborAdvertisement {
         src: Ipv6Addr,
         src_mac: MacAddr,
         target: Ipv6Addr,
     },
+    /// L3 Router Prefix Discovery
+    RouterSolicitation { src: Ipv6Addr, src_mac: MacAddr },
+    /// L3 Router Response with available segment prefixes
     RouterAdvertisement {
         src: Ipv6Addr,
         src_mac: MacAddr,
         prefixes: Vec<Ipv6Network>,
-    },
-    RouterSolicitation {
-        src: Ipv6Addr,
-        src_mac: MacAddr,
     },
 }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -7,7 +7,7 @@ use ip_network_table_deps_treebitmap::{address::Address, IpLookupTable};
 use ipnetwork::{ipv4_mask_to_prefix, ipv6_mask_to_prefix, IpNetwork, Ipv4Network, Ipv6Network};
 use pnet::datalink::{self, MacAddr, NetworkInterface};
 
-use super::arp_cache::ArpCache;
+use super::arp::ArpCache;
 
 #[derive(Debug)]
 pub struct Route {


### PR DESCRIPTION
This diff adds:
- NDP Request/Monitor structs, and NDP Cache (similar to existing ARP structs)
- NDP cache to `Route` struct
- RIB can now resolve MAC Addresses for IPv6 Addrs (using this new ndp support)